### PR TITLE
add reactor netty relocation for 10.2

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -100,6 +100,17 @@
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>ms.shaded.com.fasterxml.jackson</shadedPattern>
                 </relocation>
+
+                <!--In Databricks 10.2 you nay also need to relocate reactor netty packages-->
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>ms.shaded.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>reactor.netty</pattern>
+                  <shadedPattern>ms.shaded.reactor.netty</shadedPattern>
+                </relocation>
+
                 <relocation>
                   <!--Databricks brings its own version of azure-core which may be incompatible with blob storage version. Relocate azure-core so we don't collide with it-->
                   <pattern>com.azure</pattern>

--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -101,14 +101,14 @@
                   <shadedPattern>ms.shaded.com.fasterxml.jackson</shadedPattern>
                 </relocation>
 
-                <!--In Databricks 10.2 you nay also need to relocate reactor netty packages-->
+                <!--In Databricks 10.2 you nay also need to relocate reactor netty classes-->
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>ms.shaded.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>reactor.netty</pattern>
-                  <shadedPattern>ms.shaded.reactor.netty</shadedPattern>
+                  <pattern>reactor</pattern>
+                  <shadedPattern>ms.shaded.reactor</shadedPattern>
                 </relocation>
 
                 <relocation>


### PR DESCRIPTION
Databricks started relocating io.netty which leads to public netty APIs changing params/return types. e.g. 

`public reactor.netty.transport.ClientTransport reactor.netty.transport.ClientTransport.resolver(shaded.databricks.azurebfs.io.netty.resolver.AddressResolverGroup)`

and we fail with something like 

```
NoSuchMethodError: reactor.netty.http.client.HttpClient.resolver(Lio/netty/resolver/AddressResolverGroup;)Lreactor/netty/transport/ClientTransport;
	at com.azure.core.http.netty.NettyAsyncHttpClientBuilder.build(NettyAsyncHttpClientBuilder.java:119)
	at com.azure.core.http.netty.NettyAsyncHttpClientProvider.createInstance(NettyAsyncHttpClientProvider.java:18)
	at com.azure.core.implementation.http.HttpClientProviders.createInstance(HttpClientProviders.java:58)
	at com.azure.core.http.HttpClient.createDefault(HttpClient.java:50)
```

This is a workaround to relocate io.netty and reactor to avoid it :(